### PR TITLE
Add auth rest cancel flow endpoint

### DIFF
--- a/src/Signicat.SDK.Tests/Services/AuthenticationServiceTest.cs
+++ b/src/Signicat.SDK.Tests/Services/AuthenticationServiceTest.cs
@@ -127,7 +127,7 @@ public class AuthenticationServiceTest : BaseTest
         
         var createSession = _authenticationService.CreateSession(_headlessOptions);
         
-        var session = _authenticationService.CancelFlow(createSession.Id);
+        var session = _authenticationService.CancelSession(createSession.Id);
 
         Assert.IsNotNull(session);
         Assert.AreEqual(createSession.Id, session.Id);
@@ -141,7 +141,7 @@ public class AuthenticationServiceTest : BaseTest
     {
         var createSession = await _authenticationService.CreateSessionAsync(_headlessOptions);
         
-        var session = await _authenticationService.CancelFlowAsync(createSession.Id);
+        var session = await _authenticationService.CancelSessionAsync(createSession.Id);
 
         Assert.IsNotNull(session);
         Assert.AreEqual(createSession.Id, session.Id);

--- a/src/Signicat.SDK/Constants/AuthenticationStatus.cs
+++ b/src/Signicat.SDK/Constants/AuthenticationStatus.cs
@@ -16,5 +16,16 @@ namespace Signicat.Constants
         ///     User aborted the authentication process
         /// </summary>
         public const string Aborted = "ABORTED";
+        
+        
+        /// <summary>
+        ///     Authentication process is cancelled
+        /// </summary>
+        public const string Cancelled = "CANCELLED";
+        
+        /// <summary>
+        ///     Authentication process is waiting for the user to response (example: to a auth request on the mobile)
+        /// </summary>
+        public const string WaitingForUser = "WAITING_FOR_USER";
     }
 }

--- a/src/Signicat.SDK/Constants/AuthenticationStatus.cs
+++ b/src/Signicat.SDK/Constants/AuthenticationStatus.cs
@@ -15,7 +15,7 @@ namespace Signicat.Constants
         /// <summary>
         ///     User aborted the authentication process
         /// </summary>
-        public const string Aborted = "ABORTED";
+        public const string Aborted = "ABORT";
         
         
         /// <summary>

--- a/src/Signicat.SDK/Services/Authentication/AuthenticationService.cs
+++ b/src/Signicat.SDK/Services/Authentication/AuthenticationService.cs
@@ -54,11 +54,21 @@ namespace Signicat.Authentication
             return PostAsync<AuthenticationSession>($"{Urls.Authentication}/sessions", authenticationCreateOptions);
         }
 
+        /// <summary>
+        ///     Cancels an identification session.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
         public AuthenticationSession CancelFlow(string id)
         {
             return Post<AuthenticationSession>($"{Urls.Authentication}/sessions/{id}/cancel");
         }
 
+        /// <summary>
+        ///     Cancels an identification session.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
         public Task<AuthenticationSession> CancelFlowAsync(string id)
         {
             return PostAsync<AuthenticationSession>($"{Urls.Authentication}/sessions/{id}/cancel");

--- a/src/Signicat.SDK/Services/Authentication/AuthenticationService.cs
+++ b/src/Signicat.SDK/Services/Authentication/AuthenticationService.cs
@@ -59,7 +59,7 @@ namespace Signicat.Authentication
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public AuthenticationSession CancelFlow(string id)
+        public AuthenticationSession CancelSession(string id)
         {
             return Post<AuthenticationSession>($"{Urls.Authentication}/sessions/{id}/cancel");
         }
@@ -69,7 +69,7 @@ namespace Signicat.Authentication
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public Task<AuthenticationSession> CancelFlowAsync(string id)
+        public Task<AuthenticationSession> CancelSessionAsync(string id)
         {
             return PostAsync<AuthenticationSession>($"{Urls.Authentication}/sessions/{id}/cancel");
         }

--- a/src/Signicat.SDK/Services/Authentication/AuthenticationService.cs
+++ b/src/Signicat.SDK/Services/Authentication/AuthenticationService.cs
@@ -53,5 +53,15 @@ namespace Signicat.Authentication
         {
             return PostAsync<AuthenticationSession>($"{Urls.Authentication}/sessions", authenticationCreateOptions);
         }
+
+        public AuthenticationSession CancelFlow(string id)
+        {
+            return Post<AuthenticationSession>($"{Urls.Authentication}/sessions/{id}/cancel");
+        }
+
+        public Task<AuthenticationSession> CancelFlowAsync(string id)
+        {
+            return PostAsync<AuthenticationSession>($"{Urls.Authentication}/sessions/{id}/cancel");
+        }
     }
 }

--- a/src/Signicat.SDK/Services/Authentication/IAuthenticationService.cs
+++ b/src/Signicat.SDK/Services/Authentication/IAuthenticationService.cs
@@ -31,5 +31,19 @@ namespace Signicat.Authentication
         /// <param name="authenticationCreateOptions"></param>
         /// <returns></returns>
         Task<AuthenticationSession> CreateSessionAsync(AuthenticationCreateOptions authenticationCreateOptions);
+        
+        /// <summary>
+        ///     Cancels an identification session.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        AuthenticationSession CancelFlow(string id);
+
+        /// <summary>
+        ///     Cancels an identification session.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<AuthenticationSession> CancelFlowAsync(string id);
     }
 }

--- a/src/Signicat.SDK/Services/Authentication/IAuthenticationService.cs
+++ b/src/Signicat.SDK/Services/Authentication/IAuthenticationService.cs
@@ -37,13 +37,13 @@ namespace Signicat.Authentication
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        AuthenticationSession CancelFlow(string id);
+        AuthenticationSession CancelSession(string id);
 
         /// <summary>
         ///     Cancels an identification session.
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        Task<AuthenticationSession> CancelFlowAsync(string id);
+        Task<AuthenticationSession> CancelSessionAsync(string id);
     }
 }


### PR DESCRIPTION
- Added support for authentication rest cancel session endpoint
- Added new statuses `CANCELLED`, and `WAITING_FOR_USER`.
- Fixed abort status from `ABORTED `to correct status `ABORT`
- Added tests for the new cancel endpoint