### PR TITLE
fix: GetPackagedTaskResult

### DIFF
--- a/src/Signicat.SDK/Infrastructure/HttpRequestor.cs
+++ b/src/Signicat.SDK/Infrastructure/HttpRequestor.cs
@@ -224,10 +224,21 @@ namespace Signicat.Infrastructure
 
         private static async Task<Stream> ExecuteRawRequestAsync(HttpRequestMessage requestMessage)
         {
-            var response = await HttpClient.SendAsync(requestMessage);
+            var httpClient = SignicatConfiguration.HttpClient ?? new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+            var response = await httpClient.SendAsync(requestMessage);
             if (response.IsSuccessStatusCode)
             {
                 return await response.Content.ReadAsStreamAsync();
+            }
+
+            if (response.StatusCode == HttpStatusCode.SeeOther)
+            {
+                var url = response.Headers.Location.OriginalString;
+
+                // 🎣
+                var token = requestMessage.Headers.Authorization.ToString().Split(' ')[1];
+                var request = GetRequestMessage(url, HttpMethod.Get, token);
+                return await ExecuteRawRequestAsync(request);
             }
 
             var errorContent = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
# Changes:
* make it possible to fetch documents using the GetPackagedTaskResult API

## The Problem:
This did not work previously because auth tokens (or headers in general) are not passed to the next request following a 303 response.

## The Fix:
I fixed this by _disallowing_ the request to automatically follow redirect responses, and doing the redirect request manually with the auth token.